### PR TITLE
Accept optional leading '+' when parsing rational

### DIFF
--- a/lib/bigint.dart
+++ b/lib/bigint.dart
@@ -24,9 +24,8 @@ final _10 = new BigInt.fromJsInt(10);
 
 class BigInt {
   static BigInt parse(String text) {
-    bool isPositive = true;
-    if (text.startsWith('-')) {
-      isPositive = false;
+    bool isPositive = text.startsWith('-');
+    if (text.startsWith(new RegExp('[+-]'))) {
       text = text.substring(1);
     }
     if (!new RegExp(r'^[0-9]+$').hasMatch(text)) throw new FormatException('Invalid integer');

--- a/lib/rational.dart
+++ b/lib/rational.dart
@@ -18,7 +18,7 @@ import 'package:rational/bigint.dart';
 
 final IS_JS = identical(1, 1.0);
 
-final _PATTERN = new RegExp(r"^(-?\d+)(\.\d+)?$");
+final _PATTERN = new RegExp(r"^([+-]?\d+)(\.\d+)?$");
 
 final _0 = new Rational(0);
 final _1 = new Rational(1);

--- a/test/rational_tests.dart
+++ b/test/rational_tests.dart
@@ -9,6 +9,7 @@ main() {
   test('string validation', () {
     expect(() => p('1'), returnsNormally);
     expect(() => p('-1'), returnsNormally);
+    expect(() => p('+1'), returnsNormally);
     expect(() => p('1.'), throws);
     expect(() => p('1.0'), returnsNormally);
   });
@@ -16,6 +17,7 @@ main() {
     expect(p('1').isInteger, equals(true));
     expect(p('0').isInteger, equals(true));
     expect(p('-1').isInteger, equals(true));
+    expect(p('+1').isInteger, equals(true));
     expect(p('-1.0').isInteger, equals(true));
     expect(p('1.2').isInteger, equals(false));
     expect(p('-1.21').isInteger, equals(false));
@@ -24,6 +26,7 @@ main() {
     expect(p('1') == (p('1')), equals(true));
     expect(p('1') == (p('2')), equals(false));
     expect(p('1') == (p('1.0')), equals(true));
+    expect(p('1') == (p('+1')), equals(true));
     expect(p('1') == (p('2.0')), equals(false));
     expect(p('1') != (p('1')), equals(false));
     expect(p('1') != (p('2')), equals(true));


### PR DESCRIPTION
bigint and rational should accept optional leading '+' when parsing from string.
