### PR TITLE
Added support for scientific notation

### DIFF
--- a/lib/rational.dart
+++ b/lib/rational.dart
@@ -18,7 +18,7 @@ import 'package:rational/bigint.dart';
 
 final IS_JS = identical(1, 1.0);
 
-final _PATTERN = new RegExp(r"^([+-]?\d+)(\.\d+)?$");
+final _PATTERN = new RegExp(r"^([+-]?\d+)(\.\d+)?([eE][+-]?\d+)?$");
 
 final _0 = new Rational(0);
 final _1 = new Rational(1);
@@ -50,6 +50,7 @@ abstract class Rational<T extends dynamic/*int|BigInt*/> implements Comparable<R
     if (match == null) throw new FormatException("$decimalValue is not a valid format");
     final group1 = match.group(1);
     final group2 = match.group(2);
+    final group3 = match.group(3);
 
     var numerator = _INT_0;
     var denominator = _INT_1;
@@ -60,6 +61,17 @@ abstract class Rational<T extends dynamic/*int|BigInt*/> implements Comparable<R
       numerator = _parseInt('${group1}${group2.substring(1)}');
     } else {
       numerator = _parseInt(group1);
+    }
+    if(group3 != null) {
+      var exponent = _parseInt(group3.substring(1));
+      while(exponent > 0) {
+        numerator = numerator * _INT_10;
+        exponent--;
+      }
+      while(exponent < 0) {
+        denominator = denominator * _INT_10;
+        exponent++;
+      }
     }
     return new Rational._normalize(numerator, denominator);
   }

--- a/test/rational_tests.dart
+++ b/test/rational_tests.dart
@@ -12,6 +12,16 @@ main() {
     expect(() => p('+1'), returnsNormally);
     expect(() => p('1.'), throws);
     expect(() => p('1.0'), returnsNormally);
+    expect(() => p('1.0e5'), returnsNormally);
+    expect(() => p('1.0e-5'), returnsNormally);
+    expect(() => p('1.0e+5'), returnsNormally);
+    expect(() => p('1e+5'), returnsNormally);
+  });
+  test('parse scientific notation', () {
+    expect(p("1.0e3"), equals(p("1000")));
+    expect(p("1e+3"), equals(p("1000")));
+    expect(p("34.5e-2"), equals(p("0.345")));
+    expect(p("345e-5"), equals(p("0.00345")));
   });
   test('get isInteger', () {
     expect(p('1').isInteger, equals(true));
@@ -21,6 +31,8 @@ main() {
     expect(p('-1.0').isInteger, equals(true));
     expect(p('1.2').isInteger, equals(false));
     expect(p('-1.21').isInteger, equals(false));
+    expect(p('1.0e4').isInteger, equals(true));
+    expect(p('1e-4').isInteger, equals(false));
   });
   test('operator ==(Rational other)', () {
     expect(p('1') == (p('1')), equals(true));


### PR DESCRIPTION
The Rational.parse method now also recognizes strings in scientific notation (f.e. "1.5e-3"). I also added some tests.
