### PR TITLE
Performance Rational without a denominator

### DIFF
--- a/lib/rational.dart
+++ b/lib/rational.dart
@@ -57,11 +57,12 @@ class Rational implements Comparable<Rational> {
   ///
   /// If the [denominator] is omitted then its value will be `1`.
   factory Rational(BigInt numerator, [BigInt? denominator]) {
-    denominator ??= _i1;
     if (denominator == _i0) {
       throw ArgumentError('zero can not be used as denominator');
     }
     if (numerator == _i0) return Rational._fromCanonicalForm(_i0, _i1);
+    if (denominator == null) return Rational._normalized(numerator, _i1);
+    denominator = _i1;
     if (denominator < _i0) {
       numerator = -numerator;
       denominator = -denominator;


### PR DESCRIPTION
If you create a Rational without a denominator, it's much faster to return instead of first calculation the gcd.