### PR TITLE
Performance Rational without a denominator

### DIFF
--- a/lib/rational.dart
+++ b/lib/rational.dart
@@ -57,7 +57,7 @@ class Rational implements Comparable<Rational> {
   ///
   /// If the [denominator] is omitted then its value will be `1`.
   factory Rational(BigInt numerator, [BigInt? denominator]) {
-    if (denominator == null) return Rational._normalized(numerator, _i1);
+    if (denominator == null) return Rational._fromCanonicalForm(numerator, _i1);
     if (denominator == _i0) {
       throw ArgumentError('zero can not be used as denominator');
     }

--- a/lib/rational.dart
+++ b/lib/rational.dart
@@ -57,7 +57,7 @@ class Rational implements Comparable<Rational> {
   ///
   /// If the [denominator] is omitted then its value will be `1`.
   factory Rational(BigInt numerator, [BigInt? denominator]) {
-    denominator ??= _i1;
+    if (denominator == null) return Rational._normalized(numerator, _i1);
     if (denominator == _i0) {
       throw ArgumentError('zero can not be used as denominator');
     }


### PR DESCRIPTION
If you create a Rational without a denominator, it's much faster to return instead of first calculation the gcd.